### PR TITLE
move rdkafka log to debug

### DIFF
--- a/kafka/worker.go
+++ b/kafka/worker.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"context"
 	"fmt"
+
 	"github.com/gojekfarm/ziggurat/v2"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
@@ -28,7 +29,6 @@ type worker struct {
 }
 
 func (w *worker) run(ctx context.Context) {
-
 	defer func() {
 		_, err := w.consumer.Commit()
 		if err != nil {
@@ -41,7 +41,7 @@ func (w *worker) run(ctx context.Context) {
 	lch := w.consumer.Logs()
 	go func() {
 		for evt := range lch {
-			w.logger.Info(evt.Message, map[string]interface{}{
+			w.logger.Debug(evt.Message, map[string]any{
 				"client": evt.Name,
 				"lvl":    evt.Level,
 			})

--- a/zigg.go
+++ b/zigg.go
@@ -3,9 +3,10 @@ package ziggurat
 import (
 	"context"
 	"errors"
-	"github.com/gojekfarm/ziggurat/v2/logger"
 	"sync"
 	"time"
+
+	"github.com/gojekfarm/ziggurat/v2/logger"
 )
 
 var ErrCleanShutdown = errors.New("clean shutdown of streams")
@@ -22,7 +23,6 @@ type Ziggurat struct {
 }
 
 func (z *Ziggurat) Run(ctx context.Context, handler Handler, consumers ...MessageConsumer) error {
-
 	z.mustInit(consumers, handler)
 
 	var wg sync.WaitGroup
@@ -70,7 +70,6 @@ func (z *Ziggurat) Run(ctx context.Context, handler Handler, consumers ...Messag
 	}
 
 	return ErrCleanShutdown
-
 }
 
 func (z *Ziggurat) mustInit(consumers []MessageConsumer, handler Handler) {


### PR DESCRIPTION
Premise is that, we use info level for captuign events in the service that are significant to the application's business purpose, whereas debug level can be used for logging messages that aid developers to identify issues during a debugging sessions.

logs from rdkafka are too technical to be put in info, as info will contain business logic observed on staging, so moving this to debug should help to reduce the noise.